### PR TITLE
fix: ls differentiate exit codes for empty and non-existent buckets

### DIFF
--- a/command/ls.go
+++ b/command/ls.go
@@ -200,6 +200,9 @@ func (l List) Run(ctx context.Context) error {
 		}
 
 		if err := object.Err; err != nil {
+			if err.Error() == "no object found" {
+				return nil
+			}
 			merror = multierror.Append(merror, err)
 			printError(l.fullCommand, l.op, err)
 			continue

--- a/command/ls.go
+++ b/command/ls.go
@@ -200,9 +200,6 @@ func (l List) Run(ctx context.Context) error {
 		}
 
 		if err := object.Err; err != nil {
-			if err.Error() == "no object found" {
-				return nil
-			}
 			merror = multierror.Append(merror, err)
 			printError(l.fullCommand, l.op, err)
 			continue

--- a/e2e/ls_test.go
+++ b/e2e/ls_test.go
@@ -786,3 +786,20 @@ func TestListNestedLocalFolders(t *testing.T) {
 		2: match(filepath.ToSlash("file.txt")),
 	}, trimMatch(dateRe), alignment(true))
 }
+
+// ls empty bucket
+func TestEmptyBucket(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("ls", "s3://"+bucket)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{}, alignment(true))
+}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -157,10 +157,10 @@ func (s *S3) Stat(ctx context.Context, url *url.URL) (*Object, error) {
 // it sends these errors to object channel.
 func (s *S3) List(ctx context.Context, url *url.URL, _ bool) <-chan *Object {
 	if url.VersionID != "" || url.AllVersions {
-		return s.listObjectVersions(ctx, url) //
+		return s.listObjectVersions(ctx, url)
 	}
 	if s.useListObjectsV1 {
-		return s.listObjects(ctx, url) //
+		return s.listObjects(ctx, url)
 	}
 
 	return s.listObjectsV2(ctx, url)

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -157,10 +157,10 @@ func (s *S3) Stat(ctx context.Context, url *url.URL) (*Object, error) {
 // it sends these errors to object channel.
 func (s *S3) List(ctx context.Context, url *url.URL, _ bool) <-chan *Object {
 	if url.VersionID != "" || url.AllVersions {
-		return s.listObjectVersions(ctx, url)
+		return s.listObjectVersions(ctx, url) //
 	}
 	if s.useListObjectsV1 {
-		return s.listObjects(ctx, url)
+		return s.listObjects(ctx, url) //
 	}
 
 	return s.listObjectsV2(ctx, url)
@@ -378,7 +378,7 @@ func (s *S3) listObjectsV2(ctx context.Context, url *url.URL) <-chan *Object {
 			return
 		}
 
-		if !objectFound {
+		if !objectFound && !url.IsBucket() {
 			objCh <- &Object{Err: ErrNoObjectFound}
 		}
 	}()

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -288,7 +288,7 @@ func (s *S3) listObjectVersions(ctx context.Context, url *url.URL) <-chan *Objec
 			return
 		}
 
-		if !objectFound {
+		if !objectFound && !url.IsBucket() {
 			objCh <- &Object{Err: ErrNoObjectFound}
 		}
 	}()
@@ -470,7 +470,7 @@ func (s *S3) listObjects(ctx context.Context, url *url.URL) <-chan *Object {
 			return
 		}
 
-		if !objectFound {
+		if !objectFound && !url.IsBucket() {
 			objCh <- &Object{Err: ErrNoObjectFound}
 		}
 	}()


### PR DESCRIPTION
Previously, s5cmd ls returned an exit code of 1 for both empty buckets and non-existent buckets, making it difficult to differentiate between the two cases. This change updates the behavior to:

- Return exit code 0 for empty buckets, similar to the behavior of s3cmd.
- Return exit code 1 for non-existent buckets, providing a clear distinction.

Example behavior after the change:
- s5cmd ls s3://empty-bucket returns exit code 0. It does not print anything.
- s5cmd ls s3://non-existent-bucket returns exit code 1 with an appropriate error message.

Also, select command with --all-versions true flag no longer prints "ERROR " s3://bucket/": no object found" message for empty buckets.
Similarly, du command used to print 
"ERROR "du s3://empty-bucket": no object found
0 bytes in 0 objects: s3://empty-bucket"
Now it will omit "ERROR "du s3://bucket": no object found" part. They both exits with 0 without any change.